### PR TITLE
ci: add TypeSpec compile workflow

### DIFF
--- a/.github/workflows/typespec.yml
+++ b/.github/workflows/typespec.yml
@@ -1,0 +1,20 @@
+# .github/workflows/typespec.yml
+name: TypeSpec Compile
+
+on:
+  push:
+    branches: [ main ]          # main 直 push
+  pull_request:                 # すべての PR（main 宛デフォルト）
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run tsp:compile


### PR DESCRIPTION
<p>このプルリクエストでは、TypeSpec のコンパイルを自動化する <strong>GitHub Actions ワークフロー</strong> を追加しました。<br>
ワークフローは <strong><code inline="">main</code> ブランチへの push</strong> と <strong>Pull Request の各イベント</strong> をトリガーに実行され、常に TypeSpec のコンパイルが行われるようになります。</p>
<h3>変更点 / 追加内容</h3>

ファイル | 内容
-- | --
.github/workflows/typespec.yml | 新しいワークフロー “TypeSpec Compile” を追加。‐ ランナー: ubuntu-latest‐ Node.js 20 をセットアップ（npm キャッシュ有効）‐ npm ci で依存関係をインストール‐ npm run tsp:compile を実行し TypeSpec をコンパイル


<hr></body></html><!--EndFragment-->
</body>
</html>