### PR TITLE
Use environment variable for JWT key

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,3 +3,6 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=authdemo
 DB_CONN=Host=host.docker.internal;Port=5432;Database=authdemo;Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}
+
+# JWT
+JWT_KEY=your-development-jwt-key

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -4,7 +4,6 @@
   },
   "Jwt": {
     "Issuer": "AuthDemo",
-    "Audience": "AuthDemo",
-    "Key": "DevOnly__ThisIsATemporaryKeyForDevelopment2025"
+    "Audience": "AuthDemo"
   }
 }

--- a/src/AuthDemo.Api/Extensions/JwtAuthenticationExtensions.cs
+++ b/src/AuthDemo.Api/Extensions/JwtAuthenticationExtensions.cs
@@ -24,6 +24,16 @@ public static class JwtAuthenticationExtensions
             throw new InvalidOperationException("JwtOptions configuration is missing");
         }
 
+        var envKey = Environment.GetEnvironmentVariable("JWT_KEY");
+        if (!string.IsNullOrWhiteSpace(envKey))
+        {
+            jwtOptions.Key = envKey;
+        }
+        if (string.IsNullOrWhiteSpace(jwtOptions.Key))
+        {
+            throw new InvalidOperationException("JWT key is not configured");
+        }
+
         // JWT Bearer認証を追加
         services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(options =>


### PR DESCRIPTION
## Summary
- remove the development JWT key from `appsettings.Development.json`
- read the key from the `JWT_KEY` environment variable in `JwtAuthenticationExtensions`
- document the environment variable in `.env.sample`

## Testing
- `npm run tsp:compile` *(fails: `tsp: Permission denied`)*

------
https://chatgpt.com/codex/tasks/task_e_68731c3afb7c8327bb3beadcab27c4e3