### PR TITLE
Add zero clock skew for JWT validation

### DIFF
--- a/src/AuthDemo.Api/Extensions/JwtAuthenticationExtensions.cs
+++ b/src/AuthDemo.Api/Extensions/JwtAuthenticationExtensions.cs
@@ -37,7 +37,8 @@ public static class JwtAuthenticationExtensions
                     ValidIssuer = jwtOptions.Issuer,
                     ValidAudience = jwtOptions.Audience,
                     IssuerSigningKey = new SymmetricSecurityKey(
-                        Encoding.UTF8.GetBytes(jwtOptions.Key))
+                        Encoding.UTF8.GetBytes(jwtOptions.Key)),
+                    ClockSkew = TimeSpan.Zero
                 };
             });
 


### PR DESCRIPTION
## Summary
- enforce exact JWT expiration by setting `ClockSkew` to `TimeSpan.Zero`

## Testing
- `npm run tsp:compile` *(fails: `tsp` Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68731c5773d48327b2493bd42419046a