### PR TITLE
Fix JWT validation and add security tests

### DIFF
--- a/AuthDemo.sln
+++ b/AuthDemo.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuthDemo.Api", "src\AuthDem
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuthDemo.Infrastructure", "src\AuthDemo.Infrastructure\AuthDemo.Infrastructure.csproj", "{9CF9ED4E-9A45-45E5-8F4F-3178184989D6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuthDemo.Api.Tests", "src\AuthDemo.Api.Tests\AuthDemo.Api.Tests.csproj", "{6B46550A-420B-4E3D-9EB2-C59836BBEC99}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,14 +43,27 @@ Global
 		{9CF9ED4E-9A45-45E5-8F4F-3178184989D6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9CF9ED4E-9A45-45E5-8F4F-3178184989D6}.Release|x64.ActiveCfg = Release|Any CPU
 		{9CF9ED4E-9A45-45E5-8F4F-3178184989D6}.Release|x64.Build.0 = Release|Any CPU
-		{9CF9ED4E-9A45-45E5-8F4F-3178184989D6}.Release|x86.ActiveCfg = Release|Any CPU
-		{9CF9ED4E-9A45-45E5-8F4F-3178184989D6}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
+                {9CF9ED4E-9A45-45E5-8F4F-3178184989D6}.Release|x86.ActiveCfg = Release|Any CPU
+                {9CF9ED4E-9A45-45E5-8F4F-3178184989D6}.Release|x86.Build.0 = Release|Any CPU
+                {6B46550A-420B-4E3D-9EB2-C59836BBEC99}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {6B46550A-420B-4E3D-9EB2-C59836BBEC99}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {6B46550A-420B-4E3D-9EB2-C59836BBEC99}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {6B46550A-420B-4E3D-9EB2-C59836BBEC99}.Debug|x64.Build.0 = Debug|Any CPU
+                {6B46550A-420B-4E3D-9EB2-C59836BBEC99}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {6B46550A-420B-4E3D-9EB2-C59836BBEC99}.Debug|x86.Build.0 = Debug|Any CPU
+                {6B46550A-420B-4E3D-9EB2-C59836BBEC99}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {6B46550A-420B-4E3D-9EB2-C59836BBEC99}.Release|Any CPU.Build.0 = Release|Any CPU
+                {6B46550A-420B-4E3D-9EB2-C59836BBEC99}.Release|x64.ActiveCfg = Release|Any CPU
+                {6B46550A-420B-4E3D-9EB2-C59836BBEC99}.Release|x64.Build.0 = Release|Any CPU
+                {6B46550A-420B-4E3D-9EB2-C59836BBEC99}.Release|x86.ActiveCfg = Release|Any CPU
+                {6B46550A-420B-4E3D-9EB2-C59836BBEC99}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{2814AB8C-89AB-4BA3-9051-287994907E62} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
-		{9CF9ED4E-9A45-45E5-8F4F-3178184989D6} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
-	EndGlobalSection
+                {2814AB8C-89AB-4BA3-9051-287994907E62} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+                {9CF9ED4E-9A45-45E5-8F4F-3178184989D6} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+                {6B46550A-420B-4E3D-9EB2-C59836BBEC99} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+        EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -43,11 +43,15 @@ dotnet ef database update --project src/AuthDemo.Infrastructure --startup-projec
     "Default": "Host=localhost;Database=authdemo;Username=postgres;Password=postgres"
   },
   "Jwt": {
-    "Issuer": "https://localhost:5173",
-    "Audience": "https://localhost:5173",
-    "Key": "your-256-bit-secret-key-here-use-env-in-production"
+    "Issuer": "AuthDemo",
+    "Audience": "AuthDemo"
   }
 }
+```
+
+環境変数 `JWT_KEY` に秘密鍵を設定します。
+```bash
+export JWT_KEY=your-development-jwt-key
 ```
 
 ## APIの実行

--- a/Spec/main.tsp
+++ b/Spec/main.tsp
@@ -10,9 +10,7 @@ using TypeSpec.Rest;
 @server("https://localhost:5173", "Local development server")
 namespace AuthDemo;
 
-@security BearerAuth {
-  type: "http";
-  scheme: "bearer";
+model BearerAuth extends TypeSpec.Http.BearerAuth {
   bearerFormat: "JWT";
 }
 

--- a/Spec/main.tsp
+++ b/Spec/main.tsp
@@ -1,5 +1,6 @@
 import "@typespec/http";
 import "@typespec/rest";
+import "@typespec/openapi";
 import "./auth.tsp";
 
 using TypeSpec.Http;
@@ -9,4 +10,11 @@ using TypeSpec.Rest;
 @server("https://localhost:5173", "Local development server")
 namespace AuthDemo;
 
+@security BearerAuth {
+  type: "http";
+  scheme: "bearer";
+  bearerFormat: "JWT";
+}
+
+@useAuth(BearerAuth)
 interface Operations extends AuthOperations {}

--- a/src/AuthDemo.Api.Tests/AuthDemo.Api.Tests.csproj
+++ b/src/AuthDemo.Api.Tests/AuthDemo.Api.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AuthDemo.Api\AuthDemo.Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/AuthDemo.Api.Tests/Security/JwtAuthenticationTests.cs
+++ b/src/AuthDemo.Api.Tests/Security/JwtAuthenticationTests.cs
@@ -1,7 +1,10 @@
+using System;
 using System.IdentityModel.Tokens.Jwt;
+using System.Net.Http;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,6 +12,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
 using AuthDemo.Api;
 using AuthDemo.Infrastructure.Persistence;
+using Xunit;
 
 namespace AuthDemo.Api.Tests.Security;
 

--- a/src/AuthDemo.Api.Tests/Security/JwtAuthenticationTests.cs
+++ b/src/AuthDemo.Api.Tests/Security/JwtAuthenticationTests.cs
@@ -95,7 +95,7 @@ public class JwtAuthenticationTests : IClassFixture<CustomWebApplicationFactory>
     [Fact]
     public async Task ProtectedEndpoint_WithInvalidSignature_Returns401()
     {
-        var token = JwtTokenHelper.CreateToken(key: "other-secret-key");
+        var token = JwtTokenHelper.CreateToken(key: "other-secret-key-12345678901234567890");
         var request = new HttpRequestMessage(HttpMethod.Get, "/profile");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         var res = await _client.SendAsync(request);
@@ -105,7 +105,7 @@ public class JwtAuthenticationTests : IClassFixture<CustomWebApplicationFactory>
     [Fact]
     public async Task ProtectedEndpoint_WithExpiredToken_Returns401()
     {
-        var token = JwtTokenHelper.CreateToken(expires: DateTime.UtcNow.AddMinutes(-5));
+        var token = JwtTokenHelper.CreateToken(notBefore: DateTime.UtcNow.AddMinutes(-10), expires: DateTime.UtcNow.AddMinutes(-5));
         var request = new HttpRequestMessage(HttpMethod.Get, "/profile");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         var res = await _client.SendAsync(request);

--- a/src/AuthDemo.Api.Tests/Security/JwtAuthenticationTests.cs
+++ b/src/AuthDemo.Api.Tests/Security/JwtAuthenticationTests.cs
@@ -57,8 +57,9 @@ public static class JwtTokenHelper
     public static string CreateToken(
         string? issuer = "AuthDemo",
         string? audience = "AuthDemo",
+        DateTime? notBefore = null,
         DateTime? expires = null,
-        string? key = "TestSecretKey_for_unit_tests_1234567890")
+        string? key = "TestSecretKey_for_unit_tests_12345678901234567890123456789012") // 32文字以上
     {
         var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key!));
         var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
@@ -67,6 +68,7 @@ public static class JwtTokenHelper
         {
             Issuer = issuer,
             Audience = audience,
+            NotBefore = notBefore ?? DateTime.UtcNow,
             Expires = expires ?? DateTime.UtcNow.AddMinutes(30),
             SigningCredentials = credentials
         });

--- a/src/AuthDemo.Api.Tests/Security/JwtAuthenticationTests.cs
+++ b/src/AuthDemo.Api.Tests/Security/JwtAuthenticationTests.cs
@@ -1,0 +1,123 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+using AuthDemo.Api;
+using AuthDemo.Infrastructure.Persistence;
+
+namespace AuthDemo.Api.Tests.Security;
+
+public class CustomWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration(config =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:Default"] = "DataSource=:memory:",
+                ["Jwt:Issuer"] = "AuthDemo",
+                ["Jwt:Audience"] = "AuthDemo"
+            });
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            var descriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+            if (descriptor != null)
+            {
+                services.Remove(descriptor);
+            }
+
+            services.AddDbContextPool<ApplicationDbContext>(opts =>
+                opts.UseInMemoryDatabase("TestDb"));
+
+            Environment.SetEnvironmentVariable("JWT_KEY", "TestSecretKey_for_unit_tests_1234567890");
+        });
+    }
+}
+
+public static class JwtTokenHelper
+{
+    public static string CreateToken(
+        string? issuer = "AuthDemo",
+        string? audience = "AuthDemo",
+        DateTime? expires = null,
+        string? key = "TestSecretKey_for_unit_tests_1234567890")
+    {
+        var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key!));
+        var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+        var handler = new JwtSecurityTokenHandler();
+        var token = handler.CreateToken(new SecurityTokenDescriptor
+        {
+            Issuer = issuer,
+            Audience = audience,
+            Expires = expires ?? DateTime.UtcNow.AddMinutes(30),
+            SigningCredentials = credentials
+        });
+        return handler.WriteToken(token);
+    }
+}
+
+public class JwtAuthenticationTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public JwtAuthenticationTests(CustomWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithoutToken_Returns401()
+    {
+        var res = await _client.GetAsync("/profile");
+        Assert.Equal(HttpStatusCode.Unauthorized, res.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithInvalidSignature_Returns401()
+    {
+        var token = JwtTokenHelper.CreateToken(key: "other-secret-key");
+        var request = new HttpRequestMessage(HttpMethod.Get, "/profile");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var res = await _client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.Unauthorized, res.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithExpiredToken_Returns401()
+    {
+        var token = JwtTokenHelper.CreateToken(expires: DateTime.UtcNow.AddMinutes(-5));
+        var request = new HttpRequestMessage(HttpMethod.Get, "/profile");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var res = await _client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.Unauthorized, res.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithWrongIssuer_Returns401()
+    {
+        var token = JwtTokenHelper.CreateToken(issuer: "OtherIssuer");
+        var request = new HttpRequestMessage(HttpMethod.Get, "/profile");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var res = await _client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.Unauthorized, res.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithWrongAudience_Returns401()
+    {
+        var token = JwtTokenHelper.CreateToken(audience: "OtherAudience");
+        var request = new HttpRequestMessage(HttpMethod.Get, "/profile");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var res = await _client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.Unauthorized, res.StatusCode);
+    }
+}

--- a/src/AuthDemo.Api.Tests/Security/JwtAuthenticationTests.cs
+++ b/src/AuthDemo.Api.Tests/Security/JwtAuthenticationTests.cs
@@ -1,4 +1,6 @@
+#nullable enable
 using System;
+using System.Threading.Tasks;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http;
 using System.Net;
@@ -13,6 +15,9 @@ using Microsoft.IdentityModel.Tokens;
 using AuthDemo.Api;
 using AuthDemo.Infrastructure.Persistence;
 using Xunit;
+
+using System.Collections.Generic;
+using System.Linq;
 
 namespace AuthDemo.Api.Tests.Security;
 

--- a/src/AuthDemo.Api/Extensions/JwtAuthenticationExtensions.cs
+++ b/src/AuthDemo.Api/Extensions/JwtAuthenticationExtensions.cs
@@ -43,11 +43,30 @@ public static class JwtAuthenticationExtensions
                     ValidateIssuer = true,
                     ValidateAudience = true,
                     ValidateLifetime = true,
+                    RequireExpirationTime = true,
                     ValidateIssuerSigningKey = true,
+                    RequireSignedTokens = true,
+                    ClockSkew = TimeSpan.Zero,
                     ValidIssuer = jwtOptions.Issuer,
                     ValidAudience = jwtOptions.Audience,
                     IssuerSigningKey = new SymmetricSecurityKey(
                         Encoding.UTF8.GetBytes(jwtOptions.Key))
+                };
+
+                options.Events = new JwtBearerEvents
+                {
+                    OnAuthenticationFailed = ctx =>
+                    {
+                        ctx.NoResult();
+                        ctx.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                        return Task.CompletedTask;
+                    },
+                    OnChallenge = ctx =>
+                    {
+                        ctx.HandleResponse();
+                        ctx.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                        return Task.CompletedTask;
+                    }
                 };
             });
 

--- a/src/AuthDemo.Api/Program.cs
+++ b/src/AuthDemo.Api/Program.cs
@@ -6,3 +6,5 @@ builder.Services.AddApplicationServices(builder.Configuration);
 var app = builder.Build();
 app.ConfigureEndpoints();
 app.Run();
+
+public partial class Program { }


### PR DESCRIPTION
## Summary
- enforce strict JWT validation and zero clock skew
- add error handling for authentication failures
- expose Program class for WebApplicationFactory
- document JWT environment variable setup
- define BearerAuth security scheme in TypeSpec
- introduce Api test project with JWT security tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687355af18048327b7ca395651265855