### PR TITLE
Fix: Remove ADDITIONAL_SECRET from enable-auto-merge workflow

### DIFF
--- a/.github/workflows/enable-auto-merge.yml
+++ b/.github/workflows/enable-auto-merge.yml
@@ -11,7 +11,6 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.number }}
       PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      ADDITIONAL_SECRET: ${{ secrets.ADDITIONAL_SECRET }}
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/enable-auto-merge.yml
+++ b/.github/workflows/enable-auto-merge.yml
@@ -10,6 +10,8 @@ jobs:
     if: ${{ github.event.pull_request.draft == false }}
     env:
       PR_NUMBER: ${{ github.event.number }}
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      ADDITIONAL_SECRET: ${{ secrets.ADDITIONAL_SECRET }}
     permissions:
       pull-requests: write
       contents: write
@@ -26,7 +28,7 @@ jobs:
           echo PR number: ${{ github.event.number }}
           echo isDraft: ${{ github.event.pull_request.draft }}
           gh pr merge "$PR_NUMBER" --merge --auto
-        # 上流から下流ブランチへのPRの場合、レビュアー承認を不要とする (mainからdevelopの場合、developからfeature/*の場合)
+      # 上流から下流ブランチへのPRの場合、レビュアー承認を不要とする (mainからdevelopの場合、developからfeature/*の場合)
       - name: For pull requests from upstream to downstream branches (e.g., from main to develop or from develop to feature/), reviewer approval is not required.
         if: ${{ github.event.pull_request.draft == false && (github.event.pull_request.head.ref == 'main' && github.event.pull_request.base.ref == 'develop' || github.event.pull_request.head.ref == 'develop' && startsWith(github.event.pull_request.base.ref, 'feature/')) }}
         uses: hmarr/auto-approve-action@v4


### PR DESCRIPTION
This PR removes the unnecessary ADDITIONAL_SECRET from the enable-auto-merge workflow.